### PR TITLE
Fixed a bug that crashes the loading of resources in screensaver

### DIFF
--- a/Snoopy/Animation.swift
+++ b/Snoopy/Animation.swift
@@ -150,6 +150,9 @@ struct AnimationCollection {
             let fileURL = files[index]
             let fileExtension = fileURL.pathExtension
             let fileName = fileURL.deletingPathExtension().lastPathComponent
+            if Self.isThumbnail(fileName) {
+                continue
+            }
             let resourceName = ParsedFileName.extractResourceName(from: fileName)
             switch fileExtension {
             case HEIC_FILE_TYPE where ParsedFileName.isSnoopyHouse(resourceName):
@@ -166,7 +169,7 @@ struct AnimationCollection {
                 case MOV_FILE_TYPE:
                     constructVideoAnimation(from: files[index ..< endOfAnimationIndex])
                 default:
-                    unreachable("unexpected file type \(fileExtension)")
+                    unreachable("unexpected file extension \"\(fileExtension)\", file is: \(fileURL.path())")
                 }
                 if ParsedFileName.isMask(resourceName) {
                     for animation in animationContexts.lazy.map(\.animation) {
@@ -188,7 +191,7 @@ struct AnimationCollection {
                 }
                 index = endOfAnimationIndex - 1
             default:
-                unreachable("unexpected file type \(fileName)")
+                unreachable("unexpected file: \(fileURL.path())")
             }
         }
         return AnimationCollection(graph: createJumpGraph(context: allContexts),
@@ -199,6 +202,10 @@ struct AnimationCollection {
                                    masks: Array(masks.values),
                                    specialImages: specialImages,
                                    background: background)
+    }
+    
+    private static func isThumbnail(_ fileName: some StringProtocol) -> Bool {
+        fileName.starts(with: "thumbnail")
     }
     
     typealias AnimationContext = (animation: Animation, source: Substring?, destination: Substring?)

--- a/Snoopy/SnoopyModel.swift
+++ b/Snoopy/SnoopyModel.swift
@@ -11,6 +11,7 @@ struct SnoopyModel {
     private let animations: AnimationCollection = {
         let resourceFiles = Bundle(for: SnoopyScene.self)
             .urls(forResourcesWithExtension: nil, subdirectory: nil) ?? []
+        Log.debug("loaded \(resourceFiles.count) resource files")
         return AnimationCollection.from(files: resourceFiles)
     }()
     


### PR DESCRIPTION
`thumbnail.png` and `thumbnail@2x.png` was not skipped, so they caused the program to crash at the unreachable branch of a switch statement. This PR fixes that by skipping the two image files