### PR TITLE
Smoother transition between videos and less memory consumption

### DIFF
--- a/Snoopy.xcodeproj/project.pbxproj
+++ b/Snoopy.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 			membershipExceptions = (
 				AnimatedImageNode.swift,
 				Animation.swift,
+				MaskedVideoNode.swift,
 				ParsedFileName.swift,
 				SnoopyModel.swift,
 				SnoopyScene.swift,
@@ -2139,6 +2140,7 @@
 			membershipExceptions = (
 				AnimatedImageNode.swift,
 				Animation.swift,
+				MaskedVideoNode.swift,
 				ParsedFileName.swift,
 				SnoopyModel.swift,
 				SnoopyScene.swift,

--- a/Snoopy/Animation.swift
+++ b/Snoopy/Animation.swift
@@ -531,4 +531,8 @@ struct ImageSequence: Equatable, Hashable {
             .map { self.fileNameWithExtension(at: $0) }
             .map { self.baseURL.appendingPathComponent($0) }
     }
+    
+    var urlsCount: Int {
+        Int(lastFile)
+    }
 }

--- a/Snoopy/MaskedVideoNode.swift
+++ b/Snoopy/MaskedVideoNode.swift
@@ -1,0 +1,41 @@
+//
+//  MaskedVideoNode.swift
+//  Snoopy
+//
+//  Created by Yaxin Cheng on 2025-08-19.
+//
+
+import SpriteKit
+import AVKit
+
+final class MaskedVideoNode: SKCropNode, SKSizedNode {
+    private let videoNode: SKVideoNode
+    
+    init(videoNode: SKVideoNode) {
+        self.videoNode = videoNode
+        super.init()
+        addChild(videoNode)
+    }
+    
+    private override init() {
+        videoNode = SKVideoNode()
+        super.init()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        videoNode = SKVideoNode()
+        super.init(coder: aDecoder)
+    }
+    
+    var size: CGSize {
+        set {
+            videoNode.size = newValue
+        } get {
+            videoNode.size
+        }
+    }
+    
+    func play() {
+        videoNode.play()
+    }
+}

--- a/Snoopy/Utils/AVKit+Extension.swift
+++ b/Snoopy/Utils/AVKit+Extension.swift
@@ -30,6 +30,10 @@ extension AVPlayer {
         var observer: Any?
     }
     
+    func waitUntil(forTime time: CMTime) async {
+        await waitUntil(forTimes: [NSValue(time: time)])
+    }
+    
     /// waitUntil does nothing but wait for the player reaches the given time.
     /// Once the time is reached, it hands the control back to the process.
     func waitUntil(forTimes times: [NSValue]) async {


### PR DESCRIPTION
* Using multiple SKVideoNodes to transit between videos more smoothly
* Do not keep video nodes alive at the class level to conserve memories