### PR TITLE
Enable more decorations

### DIFF
--- a/Snoopy/ParsedFileName.swift
+++ b/Snoopy/ParsedFileName.swift
@@ -111,7 +111,7 @@ struct ParsedFileName {
     }
 
     static func isDecoration<S: StringProtocol>(_ resourceName: S) -> Bool {
-        resourceName.starts(with: "IV") || resourceName.starts(with: "WE")
+        resourceName.starts(with: "VI") || resourceName.starts(with: "WE")
     }
 
     static func isSpecialTransition<S: StringProtocol>(_ resourceName: S) -> Bool {


### PR DESCRIPTION
* Fix the decoration name identification. `IV` => `VI`