### PR TITLE
Fix screensaver exit problem

### DIFF
--- a/Snoopy/SnoopyView.swift
+++ b/Snoopy/SnoopyView.swift
@@ -24,6 +24,10 @@ struct SnoopyView: View {
                 }
             }
             .onReceive(screenSaverStopObserver.publisher) { _ in
+                if #available(macOS 26, *) {
+                    // Hack to prevent screensaver from restarting automatically.
+                    sleep(2)
+                }
                 NSApplication.shared.terminate(nil)
             }
     }


### PR DESCRIPTION
Since macOS 26, the legacyScreensaver will restart after getting killed. See discussions at [Aerial#1396](https://github.com/JohnCoates/Aerial/issues/1396)

The current workaround is delaying the operation by 2 seconds

fix #20 